### PR TITLE
Added a pdist-like approach to save memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ Pass an distance matrix and a cluster name array along with an linkage strategy 
     Cluster cluster = alg.performClustering(distances, names,
         new AverageLinkageStrategy());
 
+Or you can input a [pdist](http://www.mathworks.com/help/stats/pdist.html)-like matrix with one row:
+
+    String[] names = new String[] { "O1", "O2", "O3", "O4", "O5", "O6" };
+    double[][] pdist = new double[][] {
+				{1,9,7,11,14,4,3,8,10,9,2,8,6,13,10}
+		};
+    ClusteringAlgorithm alg = new PDistClusteringAlgorithm();
+    Cluster cluster = alg.performClustering(pdist, names, new AverageLinkageStrategy());
+
 What you get out
 ----------------
 

--- a/src/main/java/com/apporiented/algorithm/clustering/PDistClusteringAlgorithm.java
+++ b/src/main/java/com/apporiented/algorithm/clustering/PDistClusteringAlgorithm.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright 2013 Lars Behnke
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.apporiented.algorithm.clustering;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PDistClusteringAlgorithm implements ClusteringAlgorithm {
+
+	@Override
+	public Cluster performClustering(double[][] distances,
+			String[] clusterNames, LinkageStrategy linkageStrategy) {
+
+		/* Argument checks */
+		if (distances == null || distances.length == 0) {
+			throw new IllegalArgumentException("Invalid distance matrix");
+		}
+		if (distances[0].length != clusterNames.length
+				* (clusterNames.length - 1) / 2) {
+			throw new IllegalArgumentException("Invalid cluster name array");
+		}
+		if (linkageStrategy == null) {
+			throw new IllegalArgumentException("Undefined linkage strategy");
+		}
+
+		/* Setup model */
+		List<Cluster> clusters = createClusters(clusterNames);
+		List<ClusterPair> linkages = createLinkages(distances, clusters);
+
+		/* Process */
+		HierarchyBuilder builder = new HierarchyBuilder(clusters, linkages);
+		while (!builder.isTreeComplete()) {
+			builder.agglomerate(linkageStrategy);
+		}
+
+		return builder.getRootCluster();
+	}
+
+	private List<ClusterPair> createLinkages(double[][] distances,
+			List<Cluster> clusters) {
+		List<ClusterPair> linkages = new ArrayList<ClusterPair>();
+		for (int col = 0; col < clusters.size(); col++) {
+			Cluster cluster_col = clusters.get(col);
+			for (int row = col + 1; row < clusters.size(); row++) {
+				ClusterPair link = new ClusterPair();
+				link.setLinkageDistance(distances[0][accessFunction(row, col,
+						clusters.size())]);
+				link.setlCluster(cluster_col);
+				link.setrCluster(clusters.get(row));
+				linkages.add(link);
+			}
+		}
+		return linkages;
+	}
+
+	private List<Cluster> createClusters(String[] clusterNames) {
+		List<Cluster> clusters = new ArrayList<Cluster>();
+		for (String clusterName : clusterNames) {
+			Cluster cluster = new Cluster(clusterName);
+			clusters.add(cluster);
+		}
+		return clusters;
+	}
+
+	// Credit to this function goes to
+	// http://stackoverflow.com/questions/13079563/how-does-condensed-distance-matrix-work-pdist
+	private static int accessFunction(int i, int j, int n) {
+		return n * j - j * (j + 1) / 2 + i - 1 - j;
+	}
+
+}


### PR DESCRIPTION
Hey @lbhenke, thanks for this implemmentation. It worked nicely on small datasets, but it undergone heap issues with larger datasets. I'm not sure the entire problem could be solved by this commit, however it drops `distances` size from `n*n` to `n*(n-1)/2`, since `distances` is a symmetrical matrix whose main diagonal is irrelevant.

It incorporates the strategy used by MATLAB's `pdist` function, and I also kept it a one-lined matrix so I wouldn't need to change or add headers in the `ClusteringAlgorithm` interface. 
