### PR TITLE
Improve performance #6 

### DIFF
--- a/src/main/java/com/apporiented/algorithm/clustering/Cluster.java
+++ b/src/main/java/com/apporiented/algorithm/clustering/Cluster.java
@@ -199,14 +199,14 @@ public class Cluster
     
     public String toNewickString(int indent)
     {
-    	String cdtString = "";
+        String cdtString = "";
         if(!isLeaf()) cdtString+="(";
-    	
-    	for (int i = 0; i < indent; i++) cdtString+=" ";
+
+        for (int i = 0; i < indent; i++) cdtString+=" ";
         
         
         if(isLeaf()) {
-        	cdtString+=getName();
+            cdtString+=getName();
         }
         
         List<Cluster> children = getChildren();
@@ -214,16 +214,17 @@ public class Cluster
         boolean firstChild = true;
         for (Cluster child : children)
         {
-        	cdtString+=child.toNewickString(indent);
-        	String distanceString = distance.getDistance().toString().replace(",", ".");
-        	String weightString = distance.getWeight().toString().replace(",", ".");
+            cdtString+=child.toNewickString(indent);
+            String distanceString = distance.getDistance().toString().replace(",", ".");
+            String weightString = distance.getWeight().toString().replace(",", ".");
             if(firstChild) cdtString+=":"+distanceString+",";
             else cdtString+=":"+weightString;
             
             firstChild=false;
         }
         
-        for (int i = 0; i < indent; i++) cdtString+=" ";
+        for (int i = 0; i < indent; i++)
+            cdtString += " ";
         
         if(!isLeaf()) cdtString+=")";
         

--- a/src/main/java/com/apporiented/algorithm/clustering/ClusterPair.java
+++ b/src/main/java/com/apporiented/algorithm/clustering/ClusterPair.java
@@ -22,18 +22,18 @@ public class ClusterPair implements Comparable<ClusterPair> {
 
     private Cluster lCluster;
     private Cluster rCluster;
-	private Double linkageDistance;
+    private Double linkageDistance;
 
     public ClusterPair(){
     }
 
     public ClusterPair(Cluster left, Cluster right, Double distance) {
-        lCluster=left;
-        rCluster=right;
-        linkageDistance=distance;
+        lCluster = left;
+        rCluster = right;
+        linkageDistance = distance;
     }
 
-  public Cluster getOtherCluster(Cluster c) {
+    public Cluster getOtherCluster(Cluster c) {
     return lCluster == c ? rCluster : lCluster;
   }
 

--- a/src/main/java/com/apporiented/algorithm/clustering/ClusterPair.java
+++ b/src/main/java/com/apporiented/algorithm/clustering/ClusterPair.java
@@ -27,7 +27,7 @@ public class ClusterPair implements Comparable<ClusterPair> {
     public ClusterPair(){
     }
 
-	public ClusterPair(Cluster left, Cluster right, Double distance) {
+    public ClusterPair(Cluster left, Cluster right, Double distance) {
         lCluster=left;
         rCluster=right;
         linkageDistance=distance;
@@ -53,11 +53,11 @@ public class ClusterPair implements Comparable<ClusterPair> {
         this.rCluster = rCluster;
     }
 
-	public Double getLinkageDistance() {
+    public Double getLinkageDistance() {
         return linkageDistance;
     }
 
-	public void setLinkageDistance(Double distance) {
+    public void setLinkageDistance(Double distance) {
         this.linkageDistance = distance;
     }
 
@@ -115,7 +115,7 @@ public class ClusterPair implements Comparable<ClusterPair> {
 
         Double lWeight = lCluster.getWeightValue();
         Double rWeight = rCluster.getWeightValue();
-		double weight = lWeight + rWeight;
+        double weight = lWeight + rWeight;
         cluster.getDistance().setWeight(weight);
 
         return cluster;

--- a/src/main/java/com/apporiented/algorithm/clustering/DefaultClusteringAlgorithm.java
+++ b/src/main/java/com/apporiented/algorithm/clustering/DefaultClusteringAlgorithm.java
@@ -30,11 +30,11 @@ public class DefaultClusteringAlgorithm implements ClusteringAlgorithm
     {
 
         checkArguments(distances, clusterNames, linkageStrategy);
-    /* Setup model */
+        /* Setup model */
         List<Cluster> clusters = createClusters(clusterNames);
         DistanceMap linkages = createLinkages(distances, clusters);
 
-    /* Process */
+        /* Process */
         HierarchyBuilder builder = new HierarchyBuilder(clusters, linkages);
         while (!builder.isTreeComplete())
         {
@@ -50,11 +50,11 @@ public class DefaultClusteringAlgorithm implements ClusteringAlgorithm
     {
 
         checkArguments(distances, clusterNames, linkageStrategy);
-    /* Setup model */
+        /* Setup model */
         List<Cluster> clusters = createClusters(clusterNames);
         DistanceMap linkages = createLinkages(distances, clusters);
 
-    /* Process */
+        /* Process */
         HierarchyBuilder builder = new HierarchyBuilder(clusters, linkages);
         return builder.flatAgg(linkageStrategy, threshold);
     }

--- a/src/main/java/com/apporiented/algorithm/clustering/DefaultClusteringAlgorithm.java
+++ b/src/main/java/com/apporiented/algorithm/clustering/DefaultClusteringAlgorithm.java
@@ -16,10 +16,7 @@
 
 package com.apporiented.algorithm.clustering;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
 
 public class DefaultClusteringAlgorithm implements ClusteringAlgorithm
 {
@@ -94,11 +91,11 @@ public class DefaultClusteringAlgorithm implements ClusteringAlgorithm
             throw new IllegalArgumentException("Invalid weights array");
         }
 
-    /* Setup model */
+        /* Setup model */
         List<Cluster> clusters = createClusters(clusterNames, weights);
         DistanceMap linkages = createLinkages(distances, clusters);
 
-    /* Process */
+        /* Process */
         HierarchyBuilder builder = new HierarchyBuilder(clusters, linkages);
         while (!builder.isTreeComplete())
         {

--- a/src/main/java/com/apporiented/algorithm/clustering/Distance.java
+++ b/src/main/java/com/apporiented/algorithm/clustering/Distance.java
@@ -59,8 +59,8 @@ public class Distance implements Comparable<Distance>, Cloneable {
         return distance == null ? 1 : getDistance().compareTo(distance.getDistance());
     }
 
-	@Override
-	public String toString() {
+    @Override
+    public String toString() {
 		return String.format("distance : %.2f, weight : %.2f", distance, weight);
 	}
 }

--- a/src/main/java/com/apporiented/algorithm/clustering/Distance.java
+++ b/src/main/java/com/apporiented/algorithm/clustering/Distance.java
@@ -19,7 +19,7 @@ package com.apporiented.algorithm.clustering;
 public class Distance implements Comparable<Distance>, Cloneable {
 
     private Double distance;
-	private Double weight;
+    private Double weight;
 
     public Distance() {
 		this(0.0);

--- a/src/main/java/com/apporiented/algorithm/clustering/DistanceMap.java
+++ b/src/main/java/com/apporiented/algorithm/clustering/DistanceMap.java
@@ -39,7 +39,7 @@ public class DistanceMap {
     }
 
     public List<ClusterPair> list() {
-        List<ClusterPair> l = new ArrayList<ClusterPair>();
+        List<ClusterPair> l = new ArrayList<ClusterPair>(data.size());
         for (Item clusterPair : data) {
             l.add(clusterPair.pair);
         }
@@ -96,7 +96,7 @@ public class DistanceMap {
     public Double minDist()
     {
         Item peek = data.peek();
-        if (peek!=null)
+        if (peek != null)
             return peek.pair.getLinkageDistance();
         else
             return null;

--- a/src/main/java/com/apporiented/algorithm/clustering/DistanceMap.java
+++ b/src/main/java/com/apporiented/algorithm/clustering/DistanceMap.java
@@ -70,7 +70,7 @@ public class DistanceMap {
             return false;
         }
         remove.removed = true;
-        data.remove(remove);
+        // data.remove(remove);  // bottleneck
         return true;
     }
 

--- a/src/main/java/com/apporiented/algorithm/clustering/DistanceMap.java
+++ b/src/main/java/com/apporiented/algorithm/clustering/DistanceMap.java
@@ -79,7 +79,8 @@ public class DistanceMap {
         Item e = new Item(link);
         Item existingItem = pairHash.get(e.hash);
         if (existingItem != null) {
-            System.err.println("hashCode = " + existingItem.hash + " adding redundant link:" + link + " (exist:" + existingItem + ")");
+            System.err.println("hashCode = " + existingItem.hash +
+                    " adding redundant link:" + link + " (exist:" + existingItem + ")");
             return false;
         } else {
             pairHash.put(e.hash, e);
@@ -95,7 +96,7 @@ public class DistanceMap {
     public Double minDist()
     {
         Item peek = data.peek();
-        if(peek!=null)
+        if (peek!=null)
             return peek.pair.getLinkageDistance();
         else
             return null;
@@ -105,15 +106,15 @@ public class DistanceMap {
      * Compute some kind of unique ID for a given cluster pair.
      * @return The ID
      */
-    String hashCodePair(ClusterPair link) {
+    private String hashCodePair(ClusterPair link) {
         return hashCodePair(link.getlCluster(), link.getrCluster());
     }
 
-    String hashCodePair(Cluster lCluster, Cluster rCluster) {
+    private String hashCodePair(Cluster lCluster, Cluster rCluster) {
         return hashCodePairNames(lCluster.getName(), rCluster.getName());
     }
 
-    String hashCodePairNames(String lName, String rName) {
+    private String hashCodePairNames(String lName, String rName) {
         if (lName.compareTo(rName) < 0) {
             return lName + "~~~" + rName;//getlCluster().hashCode() + 31 * (getrCluster().hashCode());
         } else {

--- a/src/main/java/com/apporiented/algorithm/clustering/HierarchyBuilder.java
+++ b/src/main/java/com/apporiented/algorithm/clustering/HierarchyBuilder.java
@@ -42,7 +42,7 @@ public class HierarchyBuilder {
      * Returns Flattened clusters, i.e. clusters that are at least apart by a given threshold
      * @param linkageStrategy
      * @param threshold
-     * @return
+     * @return flat list of clusters
      */
     public List<Cluster> flatAgg(LinkageStrategy linkageStrategy, Double threshold)
     {

--- a/src/main/java/com/apporiented/algorithm/clustering/HierarchyBuilder.java
+++ b/src/main/java/com/apporiented/algorithm/clustering/HierarchyBuilder.java
@@ -77,21 +77,21 @@ public class HierarchyBuilder {
                 Collection<Distance> distanceValues = new ArrayList<Distance>();
 
                 if (link1 != null) {
-					Double distVal = link1.getLinkageDistance();
+                    Double distVal = link1.getLinkageDistance();
                     Double weightVal = link1.getOtherCluster(iClust).getWeightValue();
                     distanceValues.add(new Distance(distVal, weightVal));
                     distances.remove(link1);
                 }
                 if (link2 != null) {
-					Double distVal = link2.getLinkageDistance();
-					Double weightVal = link2.getOtherCluster(iClust).getWeightValue();
+                    Double distVal = link2.getLinkageDistance();
+                    Double weightVal = link2.getOtherCluster(iClust).getWeightValue();
                     distanceValues.add(new Distance(distVal, weightVal));
                     distances.remove(link2);
                 }
 
                 Distance newDistance = linkageStrategy.calculateDistance(distanceValues);
 
-				newLinkage.setLinkageDistance(newDistance.getDistance());
+                newLinkage.setLinkageDistance(newDistance.getDistance());
                 distances.add(newLinkage);
 
             }

--- a/src/main/java/com/apporiented/algorithm/clustering/LinkageStrategy.java
+++ b/src/main/java/com/apporiented/algorithm/clustering/LinkageStrategy.java
@@ -20,5 +20,5 @@ import java.util.Collection;
 
 public interface LinkageStrategy {
 
-	public Distance calculateDistance(Collection<Distance> distances);
+    public Distance calculateDistance(Collection<Distance> distances);
 }

--- a/src/main/java/com/apporiented/algorithm/clustering/PDistClusteringAlgorithm.java
+++ b/src/main/java/com/apporiented/algorithm/clustering/PDistClusteringAlgorithm.java
@@ -25,7 +25,7 @@ public class PDistClusteringAlgorithm implements ClusteringAlgorithm {
     public Cluster performClustering(double[][] distances,
                                      String[] clusterNames, LinkageStrategy linkageStrategy) {
 
-		/* Argument checks */
+        /* Argument checks */
         if (distances == null || distances.length == 0) {
             throw new IllegalArgumentException("Invalid distance matrix");
         }
@@ -37,11 +37,11 @@ public class PDistClusteringAlgorithm implements ClusteringAlgorithm {
             throw new IllegalArgumentException("Undefined linkage strategy");
         }
 
-		/* Setup model */
+        /* Setup model */
         List<Cluster> clusters = createClusters(clusterNames);
         DistanceMap linkages = createLinkages(distances, clusters);
 
-		/* Process */
+        /* Process */
         HierarchyBuilder builder = new HierarchyBuilder(clusters, linkages);
         while (!builder.isTreeComplete()) {
             builder.agglomerate(linkageStrategy);
@@ -54,7 +54,7 @@ public class PDistClusteringAlgorithm implements ClusteringAlgorithm {
     public List<Cluster> performFlatClustering(double[][] distances,
                                      String[] clusterNames, LinkageStrategy linkageStrategy, Double threshold) {
 
-		/* Argument checks */
+        /* Argument checks */
         if (distances == null || distances.length == 0) {
             throw new IllegalArgumentException("Invalid distance matrix");
         }
@@ -66,11 +66,11 @@ public class PDistClusteringAlgorithm implements ClusteringAlgorithm {
             throw new IllegalArgumentException("Undefined linkage strategy");
         }
 
-		/* Setup model */
+        /* Setup model */
         List<Cluster> clusters = createClusters(clusterNames);
         DistanceMap linkages = createLinkages(distances, clusters);
 
-		/* Process */
+        /* Process */
         HierarchyBuilder builder = new HierarchyBuilder(clusters, linkages);
         return builder.flatAgg(linkageStrategy, threshold);
     }
@@ -90,7 +90,7 @@ public class PDistClusteringAlgorithm implements ClusteringAlgorithm {
                 ClusterPair link = new ClusterPair();
                 Double d = distances[0][accessFunction(row, col,
                         clusters.size())];
-				link.setLinkageDistance(d);
+                link.setLinkageDistance(d);
                 link.setlCluster(cluster_col);
                 link.setrCluster(clusters.get(row));
                 linkages.add(link);

--- a/src/main/java/com/apporiented/algorithm/clustering/visualization/ClusterComponent.java
+++ b/src/main/java/com/apporiented/algorithm/clustering/visualization/ClusterComponent.java
@@ -27,9 +27,9 @@ import com.apporiented.algorithm.clustering.Cluster;
 
 public class ClusterComponent implements Paintable {
 
-	private Cluster cluster;
-	private VCoord linkPoint;
-	private VCoord initPoint;
+    private Cluster cluster;
+    private VCoord linkPoint;
+    private VCoord initPoint;
     private boolean printName;
     private int dotRadius = 2;
     private int namePadding = 6;

--- a/src/main/java/com/apporiented/algorithm/clustering/visualization/VCoord.java
+++ b/src/main/java/com/apporiented/algorithm/clustering/visualization/VCoord.java
@@ -17,34 +17,26 @@
 package com.apporiented.algorithm.clustering.visualization;
 
 /** 
- * Virtual coordinates.
+ * Immutable Virtual coordinate.
  */
 public class VCoord {
 
-    private double x = Double.NaN;
-    private double y = Double.NaN;
+    private double x;
+    private double y;
     
     public VCoord(double x, double y) {
         this.x = x;
         this.y = y;
     }
-    
+
     public double getX() {
         return x;
-    }
-
-    public void setX(double x) {
-        this.x = x;
     }
 
     public double getY() {
         return y;
     }
 
-    public void setY(double y) {
-        this.y = y;
-    }
-    
     @Override
     public boolean equals(Object obj) {
         if (obj instanceof VCoord) {

--- a/src/test/java/com/apporiented/algorithm/clustering/ClusterPerfTest.java
+++ b/src/test/java/com/apporiented/algorithm/clustering/ClusterPerfTest.java
@@ -77,7 +77,7 @@ public class ClusterPerfTest {
 
     @Test
     public void testn() throws Exception {
-        for (int n = 2; n < 513; n = n * 2) {
+        for (int n = 1; n <= 1024; n = n * 2) {
             Long t = timeN(n);
             System.out.println(String.format("%3d nodes -> %5d ms", n, t));
         }

--- a/src/test/java/com/apporiented/algorithm/clustering/DistanceMapTest.java
+++ b/src/test/java/com/apporiented/algorithm/clustering/DistanceMapTest.java
@@ -6,9 +6,9 @@ import static org.junit.Assert.*;
 
 public class DistanceMapTest {
     DistanceMap map = new DistanceMap();
-	ClusterPair ab = new ClusterPair(new Cluster("a"), new Cluster("b"), 1.0);
-	ClusterPair bc = new ClusterPair(new Cluster("b"), new Cluster("c"), 2.0);
-	ClusterPair ca = new ClusterPair(new Cluster("c"), new Cluster("a"), 3.0);
+    ClusterPair ab = new ClusterPair(new Cluster("a"), new Cluster("b"), 1.0);
+    ClusterPair bc = new ClusterPair(new Cluster("b"), new Cluster("c"), 2.0);
+    ClusterPair ca = new ClusterPair(new Cluster("c"), new Cluster("a"), 3.0);
 
     @Test
     public void testMapWorksWithSameDistance() throws Exception {


### PR DESCRIPTION
I profiled the code and found that
99% of the time was being spent in
`data.remove(remove);`
in DistanceMap.remove(ClusterPair link)
If we simply comment that line out, and not worry about removing items from the priority queue while the agglomeration is happening, things will run _much_ faster. I don't think its that urgent to do the remove because the entire DistanceMap will be reclaimed once the agglomeration is done.
There are still memory issues for large N, but for much larger N than without this change.
Clustering of 2048 nodes took over 16 minutes before this change, but only 10 seconds after.