### PR TITLE
Bugfix: Add leafnames for DefaultClustering

### DIFF
--- a/src/main/java/com/apporiented/algorithm/clustering/DefaultClusteringAlgorithm.java
+++ b/src/main/java/com/apporiented/algorithm/clustering/DefaultClusteringAlgorithm.java
@@ -131,6 +131,7 @@ public class DefaultClusteringAlgorithm implements ClusteringAlgorithm
         for (String clusterName : clusterNames)
         {
             Cluster cluster = new Cluster(clusterName);
+            cluster.addLeafName(clusterName);
             clusters.add(cluster);
         }
         return clusters;


### PR DESCRIPTION
There was a small bug resulting in empty leafNames for clusters created with the DefaultClustering algorithm.
Made consistent with: https://github.com/damian-t/hierarchical-clustering-java/blob/46dcc622f143057f132c81c6e1c8992784a27a5a/src/main/java/com/apporiented/algorithm/clustering/PDistClusteringAlgorithm.java#L106